### PR TITLE
Paste support in console

### DIFF
--- a/jquery.console.js
+++ b/jquery.console.js
@@ -100,7 +100,9 @@
         // Globals
         var container = $(this);
         var inner = $('<div class="jquery-console-inner"></div>');
-        var typer = $('<input class="jquery-console-typer" type="text">');
+        // erjiang: changed this from a text input to a textarea so we
+        // can get pasted newlines
+        var typer = $('<textarea class="jquery-console-typer"></textarea>');
         // Prompt
         var promptBox;
         var prompt;
@@ -625,6 +627,7 @@
                     .replace(/</g,'&lt;')
                     .replace(/</g,'&lt;')
                     .replace(/ /g,'&nbsp;')
+                    .replace(/\n/g,'<br />')
                     .replace(/([^<>&]{10})/g,'$1<wbr>&shy;' + wbr)
             );
         };


### PR DESCRIPTION
Ctrl-V pastes.  The second commit adds support for multiline pastings.

Unfortunately, there's a bug with Firefox that I'm not sure how to resolve. In Firefox, Ctrl-V also prepends the letter "v" to the pasted text because the regular keypress handler handles the V anyways. I couldn't figure out how to disable that without breaking the onpaste event, so the bug remains right now.

Opera doesn't have onpaste, but does have oninput. Oninput, however, is fired for any input, including regular keypresses.  Event-cancelling (return false) is problematic because it cancels the paste event.  Perhaps magic can be done in some other way, perhaps explicitly capturing C-v.
