### PR TITLE
Added alternative iOS keycodes for iPhone et al.

### DIFF
--- a/jquery.console.js
+++ b/jquery.console.js
@@ -38,32 +38,51 @@
 //   Google Chrome 5.0.375.55 (Mac)
 
 (function($){
+    //
+    // Detect whether we are running an iOS device
+    if( navigator.platform.indexOf("iPhone") != -1 ||
+        navigator.platform.indexOf("iPod") != -1 ||
+        navigator.platform.indexOf("iPad")) {
+        $.browser.ios = true;
+    }
     $.fn.console = function(config){
         ////////////////////////////////////////////////////////////////////////
         // Constants
         // Some are enums, data types, others just for optimisation
+    if(!$.browser.ios) {
         var keyCodes = {
-	    // left
-	    37: moveBackward,
-	    // right
-	    39: moveForward,
-	    // up
-	    38: previousHistory,
-	    // down
-	    40: nextHistory,
-	    // backspace
-	    8:  backDelete,
-	    // delete
-	    46: forwardDelete,
+            // left
+            37: moveBackward,
+            // right
+            39: moveForward,
+            // up
+            38: previousHistory,
+            // down
+            40: nextHistory,
+            // backspace
+            8:  backDelete,
+            // delete
+            46: forwardDelete,
             // end
-	    35: moveToEnd,
-	    // start
-	    36: moveToStart,
-	    // return
-	    13: commandTrigger,
-	    // tab
-	    18: doNothing
-	};
+            35: moveToEnd,
+            // start
+            36: moveToStart,
+            // return
+            13: commandTrigger,
+            10: commandTrigger,
+            // tab
+            18: doNothing
+        };
+    }
+    else {
+        var keyCodes = {
+            // backspace
+            127:backDelete,
+            // return
+            10: commandTrigger,
+	    };
+    }
+
 	var ctrlCodes = {
 	    // C-a
 	    65: moveToStart,


### PR DESCRIPTION
When getting key events from the iPhone Safari browser, the codes for keypress and keydown usually are the same (except for upper/lowercase letters). Some of the navigational and command keycodes (`var keyCodes`) shadow important characters, such as left paren `(` (code 40), period `.` (code 46), and single quote `'` (code 39).

In addition, some other differences include return, which is sent as keypress/keycode 10 (NL) instead of keycode 13 (CR), and the backspace button, which is sent as as keypress 8 / keycode 127 instead of keydown 8.

This patch simply checks to see if the user agent is an iOS device, and uses a different keyCodes table if it is.

(I tested with iPhone 3.1.2.)
