### PR TITLE
Revert "Added alternative iOS keycodes for iPhone et al."

### DIFF
--- a/jquery.console.js
+++ b/jquery.console.js
@@ -38,51 +38,32 @@
 //   Google Chrome 5.0.375.55 (Mac)
 
 (function($){
-    //
-    // Detect whether we are running an iOS device
-    if( navigator.platform.indexOf("iPhone") != -1 ||
-        navigator.platform.indexOf("iPod") != -1 ||
-        navigator.platform.indexOf("iPad") != -1) {
-        $.browser.ios = true;
-    }
     $.fn.console = function(config){
         ////////////////////////////////////////////////////////////////////////
         // Constants
         // Some are enums, data types, others just for optimisation
-    if(!$.browser.ios) {
         var keyCodes = {
-            // left
-            37: moveBackward,
-            // right
-            39: moveForward,
-            // up
-            38: previousHistory,
-            // down
-            40: nextHistory,
-            // backspace
-            8:  backDelete,
-            // delete
-            46: forwardDelete,
+	    // left
+	    37: moveBackward,
+	    // right
+	    39: moveForward,
+	    // up
+	    38: previousHistory,
+	    // down
+	    40: nextHistory,
+	    // backspace
+	    8:  backDelete,
+	    // delete
+	    46: forwardDelete,
             // end
-            35: moveToEnd,
-            // start
-            36: moveToStart,
-            // return
-            13: commandTrigger,
-            10: commandTrigger,
-            // tab
-            18: doNothing
-        };
-    }
-    else {
-        var keyCodes = {
-            // backspace
-            127:backDelete,
-            // return
-            10: commandTrigger,
-	    };
-    }
-
+	    35: moveToEnd,
+	    // start
+	    36: moveToStart,
+	    // return
+	    13: commandTrigger,
+	    // tab
+	    18: doNothing
+	};
 	var ctrlCodes = {
 	    // C-a
 	    65: moveToStart,


### PR DESCRIPTION
This reverts commit e9fa1649ec3373933fc6ef97a329beff1ccb9b22.
Alternative keycodes are no longer needed for iOS because they
fixed backspace to give 8 and return to give 13 sometime between
iOS 3.1 and iOS 4.1.
