### PR TITLE
scrollToBottom doesn't work width jQuery 1.6+ because of the new the .prop() method

### DIFF
--- a/jquery.console.js
+++ b/jquery.console.js
@@ -409,7 +409,12 @@
 
         // Scroll to the bottom of the view
         function scrollToBottom() {
-            inner.attr({ scrollTop: inner.attr("scrollHeight") });;
+            if (jQuery.fn.jquery > "1.6") {
+                inner.prop({ scrollTop: inner.prop("scrollHeight") });
+            }
+            else {
+                inner.attr({ scrollTop: inner.attr("scrollHeight") });
+            }
         };
 
 	function cancelExecution() {


### PR DESCRIPTION
Following [issue #13](https://github.com/chrisdone/jquery-console/issues/13)
