### PR TITLE
OSX pasting issue - check for meta key in addition to control key when pasting with keyboard

### DIFF
--- a/jquery.console.js
+++ b/jquery.console.js
@@ -285,7 +285,7 @@
                 return false;
             }
           // // C-v: don't insert on paste event
-            if (e.ctrlKey && String.fromCharCode(keyCode).toLowerCase() == 'v') {
+            if ((e.ctrlKey || e.metaKey) && String.fromCharCode(keyCode).toLowerCase() == 'v') {
               return true;
             }
             if (acceptInput && cancelKeyPress != keyCode && keyCode >= 32){


### PR DESCRIPTION
When attempting to paste using cmd+v into a jquery-console box, the result can be seen here - https://github.com/fogus/himera/issues/2

Basically, the text is pasted, but before that the character "v" is added. This is because on OSX, the command key does not set event.ctrlKey to true, but rather event.metaKey.  This is by design on macs, as it follows the W3C Events Specification. http://www.w3.org/TR/DOM-Level-3-Events/#events-KeyboardEvent-metaKey
