### PR TITLE
No scrolling on setting focus

### DIFF
--- a/jquery.console.js
+++ b/jquery.console.js
@@ -223,7 +223,11 @@
         container.click(function(){
             inner.addClass('jquery-console-focus');
             inner.removeClass('jquery-console-nofocus');
-            typer.focus();
+            if ($.browser.webkit) {
+                typer.focusWithoutScrolling();
+            } else {
+                typer.css('position', 'fixed').focus();
+            }
             scrollToBottom();
             return false;
         });
@@ -681,5 +685,12 @@
         $(this).text(txt);
         $(this).html($(this).html().replace(/\n/g,'<br/>'));
         return this;
+    };
+
+    // Alternative method for focus without scrolling
+    $.fn.focusWithoutScrolling = function(){
+        var x = window.scrollX, y = window.scrollY;
+        $(this).focus();
+        window.scrollTo(x, y);
     };
 })(jQuery);


### PR DESCRIPTION
Hi,
On WebKit (tested on Chromium 24.0.1312.52 and WebKitGTK+ 1.8.1) and Firefox (13.0), clicking on the console `<div>` to set focus will trigger an unnecessary screen scrolling (to the top of the page), which is quite annoying, especially when multiple consoles coexist on that page. (had to scroll back to see the console)

I fixed that issue for myself. If you think it's useful, feel free to pull!
Demo: http://www.soimort.org/jquery-console/
