### PR TITLE
fix scrollToBottom() version check for jQuery > 1.10

### DIFF
--- a/jquery.console.js
+++ b/jquery.console.js
@@ -429,7 +429,12 @@
 
 		// Scroll to the bottom of the view
 		function scrollToBottom() {
-			if (jQuery.fn.jquery > "1.6") {
+			var version = jQuery.fn.jquery.split('.');
+			var major = parseInt(version[0]);
+			var minor = parseInt(version[1]);
+			
+			// check if we're using jquery > 1.6
+			if ((major == 1 && minor > 6) || major > 1) {
 				inner.prop({ scrollTop: inner.prop("scrollHeight") });
 			}
 			else {


### PR DESCRIPTION
jQuery uses a form of [semantic versioning](http://semver.org/), where 1.9 < 1.10 < 1.11. The old scrollToBottom() version check used lexicographic ordering, which doesn't work with the newest jQuery, since "1.10" < "1.6". This commit changes that check to extract each component, parse them into an int, and then compare.
