### PR TITLE
Add option to fade on console on reset

### DIFF
--- a/README
+++ b/README
@@ -47,6 +47,9 @@ Options available:
 
  cancelHandle           function  Handle a user-signaled interrupt.
 
+ fadeOnReset            bool      Whether to trigger a fade in/out when
+                                  the console is reset.  Defaults to true.
+
 LICENSE
 
 Copyright 2010 Chris Done, Simon David Pratt. All rights reserved.

--- a/jquery.console.js
+++ b/jquery.console.js
@@ -116,6 +116,7 @@
 		var promptText = '';
 		var restoreText = '';
 		var continuedText = '';
+		var fadeOnReset = config.fadeOnReset !== undefined ? config.fadeOnReset : true;
 		// Prompt history stack
 		var history = [];
 		var ringn = 0;
@@ -161,20 +162,34 @@
 		// Reset terminal
 		extern.reset = function(){
 			var welcome = (typeof config.welcomeMessage != 'undefined');
-			inner.parent().fadeOut(function(){
+
+			var removeElements = function() {
 				inner.find('div').each(function(){
 					if (!welcome) {
 						$(this).remove();
-			} else {
-			welcome = false;
+					} else {
+						welcome = false;
+					}
+				});
+			};
+
+			var focusConsole = function() {
+				inner.addClass('jquery-console-focus');
+				typer.focus();
+			};
+
+			if (fadeOnReset) {
+				inner.parent().fadeOut(function() {
+					removeElements();
+					newPromptBox();
+					inner.parent().fadeIn(focusConsole);
+				});
 			}
-				});
+			else {
+				removeElements();
 				newPromptBox();
-				inner.parent().fadeIn(function(){
-					inner.addClass('jquery-console-focus');
-					typer.focus();
-				});
-			});
+				focusConsole();
+			}
 		};
 
 		////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Gives the client the option whether to trigger a fade effect when the console
is reset.

README updated to reflect addition.
