### PR TITLE
Fix issue #32: single line selection doesn't work

### DIFF
--- a/jquery.console.js
+++ b/jquery.console.js
@@ -226,6 +226,11 @@
 		////////////////////////////////////////////////////////////////////////
 		// Handle setting focus
 		container.click(function(){
+			// Don't mess with the focus if there is an active selection
+			if (window.getSelection().toString()) {
+				return false;
+			}
+
 			inner.addClass('jquery-console-focus');
 			inner.removeClass('jquery-console-nofocus');
 			if (isWebkit) {


### PR DESCRIPTION
Not sure why, but for multi-line selection, click() is never called, why for single line it is. In any case, whenever there is a selection, we don't want to mess with the focus.
