### PR TITLE
fix #50 on haskell.org

### DIFF
--- a/jquery.console.js
+++ b/jquery.console.js
@@ -109,7 +109,7 @@
     var inner = $('<div class="jquery-console-inner"></div>');
     // erjiang: changed this from a text input to a textarea so we
     // can get pasted newlines
-    var typer = $('<textarea class="jquery-console-typer"></textarea>');
+    var typer = $('<textarea autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" class="jquery-console-typer"></textarea>');
     // Prompt
     var promptBox;
     var prompt;


### PR DESCRIPTION
jquery creates a hidden textarea, which enables Android's
autocorrection, spellchecker, and so on. Those only affect letters,
which is why only the letters refused to appear. I added html attributes
on the textarea to disable those features, and now the letters can be
typed just fine.

I will also send an identical pull request to haskell-infra/hl.