### PR TITLE
Keep welcome message (if any) after clearScreen

### DIFF
--- a/jquery.console.js
+++ b/jquery.console.js
@@ -428,14 +428,16 @@
     };
 
     function clearCurrentPrompt() {
-    	extern.promptText("");
+      extern.promptText("");
     };
 
     function clearScreen() {
-    	inner.children(".jquery-console-prompt-box, .jquery-console-message").remove();
-    	extern.report(" ");
-    	extern.promptText("");
-    	extern.focus();
+      inner.children(".jquery-console-prompt-box, .jquery-console-message").remove();
+      if (config.welcomeMessage)  
+        message(config.welcomeMessage,'jquery-console-welcome');
+      extern.report(" ");
+      extern.promptText("");
+      extern.focus();
     };
 
     function deleteNextWord() {


### PR DESCRIPTION
With this code change, jquery-console keeps welcome message (if any) after clearScreen. 
Maybe you don't want this behaviour, but from my point of view it's more intuitive like this.
I also changed some indentation to be aligned with other function.