### PR TITLE
filledText replace spaces with &nbsp;

### DIFF
--- a/jquery.console.js
+++ b/jquery.console.js
@@ -823,7 +823,7 @@
   // Simple utility for printing messages
   $.fn.filledText = function(txt){
     $(this).text(txt);
-    $(this).html($(this).html().replace(/\t/g, '&nbsp;&nbsp;').replace(/\n/g,'<br/>'));
+    $(this).html($(this).html().replace(/\t/g, '&nbsp;&nbsp;').replace(/\n/g,'<br/>').replace(/ /g, '&nbsp;'));
     return this;
   };
 


### PR DESCRIPTION
Otherwise leading spaces and consecutive spaces are squashed, which spoils console messages with significant whitespace