### PR TITLE
Add text input support for Android.

### DIFF
--- a/jquery.console.js
+++ b/jquery.console.js
@@ -293,6 +293,25 @@
       }, 0);
     });
 
+    
+    ////////////////////////////////////////////////////////////////////////
+    // Handle Android text input.
+    
+    typer.on('textInput', e => {
+        var data = e.originalEvent.data;
+        if (acceptInput) {
+           if ( typeof config.charInsertTrigger == 'undefined' || 
+               typeof config.charInsertTrigger == 'function'){
+              for(var i = 0; i < data.length; i++) {
+                if(!config.charInsertTrigger(data.charCodeAt(i))) {
+                  return;   
+                }
+              }
+                   
+              typer.consoleInsert(data);
+            }
+        }
+     });
     ////////////////////////////////////////////////////////////////////////
     // Handle key hit before translation
     // For picking up control characters like up/left/down/right


### PR DESCRIPTION
The default key events(`keydown` and `keypress`) don't work properly on Android, only `keycode` 229 is returned, this fix should solve the problem.